### PR TITLE
Regex equivalence command-line interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 dist
 cabal-dev
+.stack-work
 *.o
 *.hi
 *.chi

--- a/app/regex-equiv/Main.hs
+++ b/app/regex-equiv/Main.hs
@@ -1,0 +1,15 @@
+import qualified Data.Text as T
+import           System.Environment (getArgs)
+
+import           Equivalence
+import           Regexp.Parser
+
+main :: IO ()
+main = do
+    [sigma, in1, in2] <- getArgs
+    either handleParseError id $ do
+      r1 <- parseRegexp sigma (T.pack in1)
+      r2 <- parseRegexp sigma (T.pack in2)
+      return . print $ equiv sigma r1 r2
+  where
+    handleParseError err = putStrLn $ "Parse error: " ++ err

--- a/cftools.cabal
+++ b/cftools.cabal
@@ -25,3 +25,12 @@ library
                      , Regexp
                      , Regexp.Parser
   other-modules:       Util
+
+executable regex-equiv
+  hs-source-dirs:      src, app/regex-equiv
+  default-language:    Haskell2010
+  main-is:             Main.hs
+  build-depends:       base >= 4.7 && < 5
+                     , attoparsec >= 0.12 && < 0.14
+                     , text >= 1.0 && < 1.3
+                     , semigroups >= 0.15 && < 0.19

--- a/cftools.cabal
+++ b/cftools.cabal
@@ -1,0 +1,23 @@
+name:                cftools
+version:             0.1.0.0
+synopsis:            Tools for context-free grammars
+description:         Please see README.md
+homepage:            http://github.com/peterthiemann/cftools#readme
+license:             BSD3
+license-file:        LICENSE
+author:              Peter Thiemann
+maintainer:          https://github.com/peterthiemann
+copyright:           (C) 2013 Peter Thiemann
+category:            Language
+build-type:          Simple
+cabal-version:       >=1.10
+
+library
+  hs-source-dirs:      src
+  default-language:    Haskell2010
+  build-depends:       base >= 4.7 && < 5
+  exposed-modules:     Algo
+                     , Equivalence
+                     , Grammar
+                     , Regexp
+  other-modules:       Util

--- a/cftools.cabal
+++ b/cftools.cabal
@@ -16,8 +16,12 @@ library
   hs-source-dirs:      src
   default-language:    Haskell2010
   build-depends:       base >= 4.7 && < 5
+                     , attoparsec >= 0.12 && < 0.14
+                     , text >= 1.0 && < 1.3
+                     , semigroups >= 0.15 && < 0.19
   exposed-modules:     Algo
                      , Equivalence
                      , Grammar
                      , Regexp
+                     , Regexp.Parser
   other-modules:       Util

--- a/src/Regexp/Parser.hs
+++ b/src/Regexp/Parser.hs
@@ -1,0 +1,115 @@
+module Regexp.Parser
+( Alphabet
+, regexp
+, parseRegexp
+) where
+
+import           Prelude hiding (foldr1) -- GHC 7.8 compat
+
+import           Control.Applicative
+import           Data.Attoparsec.Text
+import           Data.Foldable (foldr1) -- GHC 7.8 compat
+import           Data.List.NonEmpty (NonEmpty(..))
+import           Data.Text (Text)
+
+import           Regexp
+
+type Alphabet t = [t]
+
+-------------------------------------------------------------------------------
+-- Parsing data structure
+
+data Prec3 t
+    = PZero
+    | POne
+    | PAtom t
+    | Parens (Prec0 t)
+  deriving (Read, Show, Eq, Ord)
+
+data Prec2 t
+    = Prec3 (Prec3 t)
+    | PStar (Prec3 t)
+  deriving (Read, Show, Eq, Ord)
+
+data Prec1 t = PDot (NonEmpty (Prec2 t))
+  deriving (Read, Show, Eq, Ord)
+
+data Prec0 t = PAlt (NonEmpty (Prec1 t))
+  deriving (Read, Show, Eq, Ord)
+
+-------------------------------------------------------------------------------
+-- Parsers
+
+between :: Parser left -> Parser right -> Parser middle -> Parser middle
+between left right middle = (left *> middle) <* right
+
+nonEmptyInfixList :: Parser a -> Parser op -> Parser (NonEmpty a)
+nonEmptyInfixList elemParser opParser
+    = (\(x:xs) -> x:|xs) <$> elemParser `sepBy1` opParser
+
+literal :: Parser a -> Parser a
+literal p = p <* skipSpace
+
+literalChar :: Char -> Parser Char
+literalChar = literal . char
+
+zeroL, oneL, lparenL, rparenL, starL, dotL, plusL :: Parser Char
+zeroL   = literalChar 'O'
+oneL    = literalChar 'E'
+lparenL = literalChar '('
+rparenL = literalChar ')'
+starL   = literalChar '*'
+dotL    = literalChar '.'
+plusL   = literalChar '+'
+
+-- Note that @zero@, @one@ and @parens@ may clash with @atom@ for some
+-- alphabets.
+prec3 :: Alphabet (Parser t) -> Parser (Prec3 t)
+prec3 sigma = zero <|> one <|> atom <|> parens
+  where
+    zero   = zeroL *> pure PZero
+    one    = oneL *> pure POne
+    atom   = literal (PAtom <$> choice sigma)
+    parens = Parens <$> between lparenL rparenL (prec0 sigma)
+
+prec2 :: Alphabet (Parser t) -> Parser (Prec2 t)
+prec2 sigma = do
+    r <- prec3 sigma
+    starL *> pure (PStar r) <|> pure (Prec3 r)
+
+prec1 :: Alphabet (Parser t) -> Parser (Prec1 t)
+prec1 sigma = PDot <$> nonEmptyInfixList (prec2 sigma) dotL
+
+prec0 :: Alphabet (Parser t) -> Parser (Prec0 t)
+prec0 sigma = PAlt <$> nonEmptyInfixList (prec1 sigma) plusL
+
+-------------------------------------------------------------------------------
+-- Conversion to AST
+
+toRE3 :: Prec3 t -> RE t
+toRE3 PZero = Zero
+toRE3 POne = One
+toRE3 (PAtom a) = Atom a
+toRE3 (Parens r) = toRE0 r
+
+toRE2 :: Prec2 t -> RE t
+toRE2 (Prec3 r) = toRE3 r
+toRE2 (PStar r) = Star (toRE3 r)
+
+toRE1 :: Prec1 t -> RE t
+toRE1 (PDot rs) = foldr1 Dot $ fmap toRE2 rs
+
+toRE0 :: Prec0 t -> RE t
+toRE0 (PAlt rs) = foldr1 Alt $ fmap toRE1 rs
+
+-------------------------------------------------------------------------------
+-- Convenience
+
+regexp :: Alphabet (Parser t) -> Parser (RE t)
+regexp sigma = toRE0 <$> prec0 sigma
+
+parseRegexp :: Alphabet Char -> Text -> Either String (RE Char)
+parseRegexp sigma
+    = parseOnly (skipSpace *> (regexp sigmaParsers <* endOfInput))
+  where
+    sigmaParsers = map char sigma

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,5 @@
+flags: {}
+packages:
+- '.'
+extra-deps: []
+resolver: lts-3.15


### PR DESCRIPTION
This PR contains code for the `regex-equiv` programme I sent earlier. The regex parser is in `src/Regexp/Parser.hs`; the rest of this pull request consists mainly of build-related boilerplate because the parser requires some external packages.
